### PR TITLE
Profiles notes are rendered with markdown/redcarpet

### DIFF
--- a/assets/javascripts/discourse/templates/profile_notes.js.handlebars
+++ b/assets/javascripts/discourse/templates/profile_notes.js.handlebars
@@ -33,12 +33,13 @@
 {{#each view.notes}}
   {{#if this.staff}}
     <div class="note staff">
-      <p><span class="user"><a href="/users/{{unbound this.user.username}}">{{this.user.name}}</a> </span> {{this.text}}</p>
+      <p><span class="user"><a href="/users/{{unbound this.user.username}}">{{this.user.name}}</a></span></p>
+      {{{this.formatted_text}}}
       <span class="timestamp">{{date this.timestamp}}</span> <span class="shared">shared with all staff</span>
   {{else}}
     <div class="note">
-      <p>{{this.text}}</p>
-      <span class="timestamp">{{date this.timestamp}}</span> <span class="private">for your eyes only</span>
+      {{{this.formatted_text}}}
+      <p><span class="timestamp">{{date this.timestamp}}</span> <span class="private">for your eyes only</span></p>
   {{/if}}
   {{#if this.topic}}
     <span class="topic-link">

--- a/profile_notes.rb
+++ b/profile_notes.rb
@@ -1,3 +1,5 @@
+require 'redcarpet'
+
 module ::ProfileNotesPlugin
 
   class ProfileNotes
@@ -20,8 +22,11 @@ module ::ProfileNotesPlugin
 
       return {notes: []} if notes.nil?
 
+      markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML)
+
       notes[:notes].each_with_index do |note, idx|
         note[:note_index] = "#{idx_key}-#{idx}"
+        note[:formatted_text] = markdown.render(note[:text])
         if note[:topic_id]
           topic = Topic.find(note[:topic_id])
           note[:topic] = {


### PR DESCRIPTION
![markdown-profile-notes](https://cloud.githubusercontent.com/assets/481602/5482866/4df2af96-86bc-11e4-9a58-f4701d9f8266.jpg)
